### PR TITLE
chore: update type tests

### DIFF
--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -7,16 +7,16 @@ const app = Fastify()
 
 app.register(fastifyRoutePreset, {
   onPresetRoute: (routeOptions, presetOptions) => {
-    expect<RouteOptions>().type.toBe(routeOptions)
-    expect<unknown>().type.toBe(presetOptions)
+    expect(routeOptions).type.toBe<RouteOptions>()
+    expect(presetOptions).type.toBe<unknown>()
   },
 })
 
 app.register(fastifyRoutePreset, {
   onPresetRoute: [
     (routeOptions, presetOptions) => {
-      expect<RouteOptions>().type.toBe(routeOptions)
-      expect<unknown>().type.toBe(presetOptions)
+      expect(routeOptions).type.toBe<RouteOptions>()
+      expect(presetOptions).type.toBe<unknown>()
     },
   ],
 })


### PR DESCRIPTION
Glad to see you found TSTyche useful. I am its author.

Just wanted to draw your attention that the expected type should be passed to the matcher. Although it will work both ways with `.toBe()`, but reads better.

By the way, you would notice a difference using matchers like `. toBeCallableWith()` or `.toHaveProperty()`.
