### PR TITLE
feat: support ignoring preset routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ The resulting routes will have the preset configurations automatically applied:
 // POST /user/ - with tags: ['user'], version: '1.0.0'
 ```
 
+## Ignoring Preset for Specific Routes
+
+You can opt out of applying a preset configuration to specific routes by setting `config.presetRoute` to `false` within the route definition.
+
+```javascript
+fastify.get('/ignore', { config: { presetRoute: false } }, () => {})
+```
+
 ## Advanced Usage
 
 ### Multiple Handlers

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ The resulting routes will have the preset configurations automatically applied:
 
 ## Ignoring Preset for Specific Routes
 
-You can opt out of applying a preset configuration to specific routes by setting `config.presetRoute` to `false` within the route definition.
+Presets are applied by default; set `skipPreset: true` to opt out
 
 ```javascript
-fastify.get('/ignore', { config: { presetRoute: false } }, () => {})
+fastify.get('/ignore', { config: { skipPreset: true } }, () => {})
 ```
 
 ## Advanced Usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,14 @@
 import type { FastifyPluginCallback, RouteOptions } from 'fastify'
 
+declare module 'fastify' {
+  interface FastifyContextConfig {
+    /**
+     * If set to `false`, the route will not be registered with a preset configuration.
+     */
+    presetRoute?: boolean
+  }
+}
+
 type FastifyRoutePreset = FastifyPluginCallback<fastifyRoutePreset.FastifyRoutePresetOptions>
 
 declare namespace fastifyRoutePreset {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,9 @@ import type { FastifyPluginCallback, RouteOptions } from 'fastify'
 declare module 'fastify' {
   interface FastifyContextConfig {
     /**
-     * If set to `false`, the route will not be registered with a preset configuration.
+     * If set to `true`, the route will not be registered with a preset configuration.
      */
-    presetRoute?: boolean
+    skipPreset?: boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function plugin(fastify, pluginOptions, next) {
   })
 
   fastify.addHook('onRoute', function (routeOptions) {
-    if (this[kRoutePreset]) {
+    if (this[kRoutePreset] && routeOptions.config?.presetRoute !== false) {
       for (const fn of onPresetRouteFns) {
         fn(routeOptions, this[kRoutePreset])
       }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function plugin(fastify, pluginOptions, next) {
   })
 
   fastify.addHook('onRoute', function (routeOptions) {
-    if (this[kRoutePreset] && routeOptions.config?.presetRoute !== false) {
+    if (this[kRoutePreset] && !routeOptions.config?.skipPreset) {
       for (const fn of onPresetRouteFns) {
         fn(routeOptions, this[kRoutePreset])
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -226,11 +226,11 @@ test('should work with array of "onPresetRoute"', async (t) => {
   t.assert.strictEqual(routes[1].constraints.version, '1.0.0')
 })
 
-test('should ignore route preset if "presetRoute" config are false', async (t) => {
+test('should ignore route preset if "skipPreset" config are true', async (t) => {
   t.plan(4)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
-  let runner = 0
+  let presetCalls = 0
 
   fastify.register(require('./fixtures/utils').printRoutes)
   fastify.register(fastifyRoutePreset, {
@@ -240,7 +240,7 @@ test('should ignore route preset if "presetRoute" config are false', async (t) =
         ...routeOptions.schema,
       }
 
-      runner++
+      presetCalls++
     },
   })
 
@@ -250,7 +250,7 @@ test('should ignore route preset if "presetRoute" config are false', async (t) =
         return { users: [] }
       })
 
-      fastify.get('/ignore', { config: { presetRoute: false } }, async () => {
+      fastify.get('/ignore', { config: { skipPreset: true } }, async () => {
         return { users: [] }
       })
     },
@@ -264,7 +264,7 @@ test('should ignore route preset if "presetRoute" config are false', async (t) =
   await fastify.ready()
   const routes = fastify.routes()
 
-  t.assert.strictEqual(runner, 1)
+  t.assert.strictEqual(presetCalls, 1)
   t.assert.strictEqual(routes.length, 2)
   t.assert.deepStrictEqual(routes[0].schema.tags, ['users'])
   t.assert.strictEqual(routes[1].schema, undefined)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -225,3 +225,47 @@ test('should work with array of "onPresetRoute"', async (t) => {
   t.assert.deepStrictEqual(routes[1].schema.tags, ['example'])
   t.assert.strictEqual(routes[1].constraints.version, '1.0.0')
 })
+
+test('should ignore route preset if "presetRoute" config are false', async (t) => {
+  t.plan(4)
+  const fastify = Fastify({ exposeHeadRoutes: false })
+
+  let runner = 0
+
+  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(fastifyRoutePreset, {
+    onPresetRoute: (routeOptions, presetOptions) => {
+      routeOptions.schema = {
+        ...presetOptions.schema,
+        ...routeOptions.schema,
+      }
+
+      runner++
+    },
+  })
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get('/', async () => {
+        return { users: [] }
+      })
+
+      fastify.get('/ignore', { config: { presetRoute: false } }, async () => {
+        return { users: [] }
+      })
+    },
+    {
+      preset: {
+        schema: { tags: ['users'] },
+      },
+    },
+  )
+
+  await fastify.ready()
+  const routes = fastify.routes()
+
+  t.assert.strictEqual(runner, 1)
+  t.assert.strictEqual(routes.length, 2)
+  t.assert.deepStrictEqual(routes[0].schema.tags, ['users'])
+  t.assert.strictEqual(routes[1].schema, undefined)
+})

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -44,4 +44,4 @@ app.register(fastifyRoutePreset, {
   },
 })
 
-app.get('/foo', { config: { presetRoute: false } }, () => {})
+app.get('/foo', { config: { skipPreset: true } }, () => {})

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -43,3 +43,5 @@ app.register(fastifyRoutePreset, {
     expect(presetOptions).type.toBe<PresetOptions>()
   },
 })
+
+app.get('/foo', { config: { presetRoute: false } }, () => {})


### PR DESCRIPTION
close #10 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to disable preset configurations for specific routes by setting `skipPreset` to `true` in the route config.
- **Documentation**
  - Updated the README with instructions and an example on how to ignore presets for individual routes.
- **Tests**
  - Added tests to verify that routes with `skipPreset: true` do not apply preset configurations.
- **Type Declarations**
  - Extended type definitions to include the optional `skipPreset` property in route configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->