### PR TITLE
feat: skipHeadRoutes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ Presets are applied by default; set `skipPreset: true` to opt out
 fastify.get('/ignore', { config: { skipPreset: true } }, () => {})
 ```
 
+## Skip HEAD Routes Globally
+
+If you want to exclude all HEAD routes from preset application, use the `skipHeadRoutes` plugin option
+(default is false)
+
+```javascript
+fastify.register(fastifyRoutePreset, {
+  skipHeadRoutes: true, // Skip preset application for all HEAD routes
+  onPresetRoute: (routeOptions, presetOptions) => {
+    // This will not be called for HEAD routes
+    routeOptions.schema = {
+      ...presetOptions.schema,
+      ...routeOptions.schema,
+    }
+  }
+})
+```
+
 ## Advanced Usage
 
 ### Multiple Handlers

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ fastify.register(fastifyRoutePreset, {
 })
 ```
 
+> **Note:** This affects auto-exposed HEAD routes only when Fastify is created with exposeHeadRoutes: true (default in v5). If exposeHeadRoutes is false, only explicitly declared HEAD routes are affected.
+
 ## Advanced Usage
 
 ### Multiple Handlers

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,12 @@ type FastifyRoutePreset = FastifyPluginCallback<fastifyRoutePreset.FastifyRouteP
 declare namespace fastifyRoutePreset {
   export interface FastifyRoutePresetOptions {
     /**
+     * If set to `true`, the head routes will not be registered with a preset configuration.
+     *
+     * @default false
+     */
+    skipHeadRoutes?: boolean
+    /**
      * A function or array of functions that will be called when a route is registered with a preset.
      * The function will be called with the route options and the preset options.
      * 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,8 @@ type FastifyRoutePreset = FastifyPluginCallback<fastifyRoutePreset.FastifyRouteP
 declare namespace fastifyRoutePreset {
   export interface FastifyRoutePresetOptions {
     /**
-     * If set to `true`, the head routes will not be registered with a preset configuration.
+     * If set to `true`, HEAD routes will not be registered with a preset configuration.
+     * Skips both auto-exposed HEADs and user-declared HEAD routes.
      *
      * @default false
      */

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function plugin(fastify, pluginOptions, next) {
   fastify.decorate(kRoutePreset, null)
 
   let onPresetRouteFns = pluginOptions.onPresetRoute
+  const skipHeadRoutes = pluginOptions.skipHeadRoutes || false
 
   if (typeof onPresetRouteFns === 'function') {
     onPresetRouteFns = [onPresetRouteFns]
@@ -31,10 +32,16 @@ function plugin(fastify, pluginOptions, next) {
   })
 
   fastify.addHook('onRoute', function (routeOptions) {
-    if (this[kRoutePreset] && !routeOptions.config?.skipPreset) {
-      for (const fn of onPresetRouteFns) {
-        fn(routeOptions, this[kRoutePreset])
-      }
+    if (!this[kRoutePreset] || routeOptions.config?.skipPreset) {
+      return
+    }
+
+    if (skipHeadRoutes && routeOptions.method === 'HEAD') {
+      return
+    }
+
+    for (const fn of onPresetRouteFns) {
+      fn(routeOptions, this[kRoutePreset])
     }
   })
 

--- a/test-types/index.tst.ts
+++ b/test-types/index.tst.ts
@@ -10,6 +10,7 @@ app.register(fastifyRoutePreset, {
     expect(routeOptions).type.toBe<RouteOptions>()
     expect(presetOptions).type.toBe<any>()
   },
+  skipHeadRoutes: true,
 })
 
 app.register(fastifyRoutePreset, {
@@ -19,6 +20,7 @@ app.register(fastifyRoutePreset, {
       expect(presetOptions).type.toBe<any>()
     },
   ],
+  skipHeadRoutes: false,
 })
 
 app.register(fastifyRoutePreset, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -272,7 +272,7 @@ test('should ignore route preset if "skipPreset" config are true', async (t) => 
 
 test('should work with "skipHeadRoutes" config (default)', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ exposeHeadRoutes: true })
 
   let presetCalls = 0
   const methods = []
@@ -300,12 +300,12 @@ test('should work with "skipHeadRoutes" config (default)', async (t) => {
   await fastify.ready()
 
   t.assert.strictEqual(presetCalls, 2)
-  t.assert.deepStrictEqual(methods, ['GET', 'HEAD'])
+  t.assert.deepStrictEqual(methods.sort(), ['GET', 'HEAD'])
 })
 
 test('should work with "skipHeadRoutes" config is false', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ exposeHeadRoutes: true })
 
   let presetCalls = 0
   const methods = []
@@ -334,12 +334,12 @@ test('should work with "skipHeadRoutes" config is false', async (t) => {
   await fastify.ready()
 
   t.assert.strictEqual(presetCalls, 2)
-  t.assert.deepStrictEqual(methods, ['GET', 'HEAD'])
+  t.assert.deepStrictEqual(methods.sort(), ['GET', 'HEAD'])
 })
 
 test('should work with "skipHeadRoutes" config is true', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ exposeHeadRoutes: true })
 
   let presetCalls = 0
   const methods = []

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -269,3 +269,95 @@ test('should ignore route preset if "skipPreset" config are true', async (t) => 
   t.assert.deepStrictEqual(routes[0].schema.tags, ['users'])
   t.assert.strictEqual(routes[1].schema, undefined)
 })
+
+test('should work with "skipHeadRoutes" config (default)', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let presetCalls = 0
+
+  fastify.register(fastifyRoutePreset, {
+    onPresetRoute: (_routeOptions, _presetOptions) => {
+      presetCalls++
+    },
+  })
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get('/', async () => {
+        return { users: [] }
+      })
+    },
+    {
+      preset: {
+        schema: { tags: ['users'] },
+      },
+    },
+  )
+
+  await fastify.ready()
+
+  t.assert.strictEqual(presetCalls, 2)
+})
+
+test('should work with "skipHeadRoutes" config is false', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let presetCalls = 0
+
+  fastify.register(fastifyRoutePreset, {
+    skipHeadRoutes: false,
+    onPresetRoute: (_routeOptions, _presetOptions) => {
+      presetCalls++
+    },
+  })
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get('/', async () => {
+        return { users: [] }
+      })
+    },
+    {
+      preset: {
+        schema: { tags: ['users'] },
+      },
+    },
+  )
+
+  await fastify.ready()
+
+  t.assert.strictEqual(presetCalls, 2)
+})
+
+test('should work with "skipHeadRoutes" config is true', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  let presetCalls = 0
+
+  fastify.register(fastifyRoutePreset, {
+    skipHeadRoutes: true,
+    onPresetRoute: (_routeOptions, _presetOptions) => {
+      presetCalls++
+    },
+  })
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get('/', async () => {
+        return { users: [] }
+      })
+    },
+    {
+      preset: {
+        schema: { tags: ['users'] },
+      },
+    },
+  )
+
+  await fastify.ready()
+
+  t.assert.strictEqual(presetCalls, 1)
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,14 +271,16 @@ test('should ignore route preset if "skipPreset" config are true', async (t) => 
 })
 
 test('should work with "skipHeadRoutes" config (default)', async (t) => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   let presetCalls = 0
+  const methods = []
 
   fastify.register(fastifyRoutePreset, {
-    onPresetRoute: (_routeOptions, _presetOptions) => {
+    onPresetRoute: (routeOptions, _presetOptions) => {
       presetCalls++
+      methods.push(routeOptions.method)
     },
   })
 
@@ -298,18 +300,21 @@ test('should work with "skipHeadRoutes" config (default)', async (t) => {
   await fastify.ready()
 
   t.assert.strictEqual(presetCalls, 2)
+  t.assert.deepStrictEqual(methods, ['GET', 'HEAD'])
 })
 
 test('should work with "skipHeadRoutes" config is false', async (t) => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   let presetCalls = 0
+  const methods = []
 
   fastify.register(fastifyRoutePreset, {
     skipHeadRoutes: false,
-    onPresetRoute: (_routeOptions, _presetOptions) => {
+    onPresetRoute: (routeOptions, _presetOptions) => {
       presetCalls++
+      methods.push(routeOptions.method)
     },
   })
 
@@ -329,18 +334,21 @@ test('should work with "skipHeadRoutes" config is false', async (t) => {
   await fastify.ready()
 
   t.assert.strictEqual(presetCalls, 2)
+  t.assert.deepStrictEqual(methods, ['GET', 'HEAD'])
 })
 
 test('should work with "skipHeadRoutes" config is true', async (t) => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   let presetCalls = 0
+  const methods = []
 
   fastify.register(fastifyRoutePreset, {
     skipHeadRoutes: true,
-    onPresetRoute: (_routeOptions, _presetOptions) => {
+    onPresetRoute: (routeOptions, _presetOptions) => {
       presetCalls++
+      methods.push(routeOptions.method)
     },
   })
 
@@ -360,4 +368,5 @@ test('should work with "skipHeadRoutes" config is true', async (t) => {
   await fastify.ready()
 
   t.assert.strictEqual(presetCalls, 1)
+  t.assert.deepStrictEqual(methods, ['GET'])
 })


### PR DESCRIPTION
close #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added plugin option to skip auto-generated HEAD routes (skipHeadRoutes, default: false).

- Documentation
  - Updated README with usage and example for skipHeadRoutes.
  - Expanded Advanced Usage to demonstrate supplying multiple preset handlers applied in order.

- Tests
  - Added tests verifying default, explicit false, and true behaviors for skipHeadRoutes and expected method handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->