### PR TITLE
feat: migrate fastify-route-preset to ESM

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace fastifyRoutePreset {
     /**
      * A function or array of functions that will be called when a route is registered with a preset.
      * The function will be called with the route options and the preset options.
-     * 
+     *
      * @example
      * ```js
      * fastify.register(fastifyRoutePreset, {
@@ -38,13 +38,11 @@ declare namespace fastifyRoutePreset {
   }
 
   export type OnPresetRoute = (routeOptions: RouteOptions, presetOptions: any) => void
-
-  export const fastifyRoutePreset: FastifyRoutePreset
-  export { fastifyRoutePreset as default }
 }
 
-declare function fastifyRoutePreset(
-  ...params: Parameters<FastifyRoutePreset>
-): ReturnType<FastifyRoutePreset>
+declare const fastifyRoutePreset: FastifyRoutePreset
 
-export = fastifyRoutePreset
+export type FastifyRoutePresetOptions = fastifyRoutePreset.FastifyRoutePresetOptions
+export type OnPresetRoute = fastifyRoutePreset.OnPresetRoute
+export { fastifyRoutePreset }
+export default fastifyRoutePreset

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-'use strict'
-
-const fp = require('fastify-plugin')
+import fp from 'fastify-plugin'
 
 const kRoutePreset = Symbol('fastifyRoutePreset')
 
 /**
- * @type {import('fastify').FastifyPluginCallback<import('.').FastifyRoutePresetOptions>}
+ * @type {import('fastify').FastifyPluginCallback<import('./index.js').FastifyRoutePresetOptions>}
  */
 function plugin(fastify, pluginOptions, next) {
   fastify.decorate(kRoutePreset, null)
@@ -53,6 +51,5 @@ const fastifyRoutePreset = fp(plugin, {
   name: 'fastify-route-preset',
 })
 
-module.exports = fastifyRoutePreset
-module.exports.default = fastifyRoutePreset
-module.exports.fastifyRoutePreset = fastifyRoutePreset
+export { fastifyRoutePreset }
+export default fastifyRoutePreset

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "fastify-route-preset",
   "version": "1.0.2",
   "description": "A Fastify plugin for applying reusable route configurations through preset-based modifications.",
-  "type": "commonjs",
+  "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "types": "index.d.ts",
   "scripts": {
     "lint": "biome check",

--- a/test-types/index.tst.ts
+++ b/test-types/index.tst.ts
@@ -1,7 +1,9 @@
 import type { RouteOptions } from 'fastify'
 import Fastify from 'fastify'
+import fastifyRoutePreset, {
+  fastifyRoutePreset as namedFastifyRoutePreset,
+} from 'fastify-route-preset'
 import { expect } from 'tstyche'
-import fastifyRoutePreset from '..'
 
 const app = Fastify()
 
@@ -44,6 +46,10 @@ app.register(fastifyRoutePreset, {
     expect(routeOptions).type.toBe<RouteOptions>()
     expect(presetOptions).type.toBe<PresetOptions>()
   },
+})
+
+app.register(namedFastifyRoutePreset, {
+  onPresetRoute: [],
 })
 
 app.get('/foo', { config: { skipPreset: true } }, () => {})

--- a/test/autoload.test.js
+++ b/test/autoload.test.js
@@ -1,25 +1,26 @@
-'use strict'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import fastifyAutoload from '@fastify/autoload'
+import Fastify from 'fastify'
+import fastifyRoutePreset from '../index.js'
+import { presetSchema, presetVersion } from './fixtures/preset.js'
+import { printRoutes } from './fixtures/utils.js'
 
-const { test } = require('node:test')
-const Fastify = require('fastify')
-const fastifyRoutePreset = require('..')
-const path = require('node:path')
-const fastifyAutoload = require('@fastify/autoload')
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 test('should work with @fastify/autoload', async (t) => {
   t.plan(9)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
-    onPresetRoute: [
-      require('./fixtures/preset').presetSchema,
-      require('./fixtures/preset').presetVersion,
-    ],
+    onPresetRoute: [presetSchema, presetVersion],
   })
 
   fastify.register(fastifyAutoload, {
-    dir: path.join(__dirname, 'fixtures/routes'),
+    dir: join(__dirname, 'fixtures/routes'),
     dirNameRoutePrefix: false,
   })
 
@@ -44,21 +45,18 @@ test('should work with @fastify/autoload (multiple instances)', async (t) => {
   t.plan(9)
   const fastify = Fastify({ exposeHeadRoutes: false })
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
-    onPresetRoute: [
-      require('./fixtures/preset').presetSchema,
-      require('./fixtures/preset').presetVersion,
-    ],
+    onPresetRoute: [presetSchema, presetVersion],
   })
 
   fastify.register(fastifyAutoload, {
-    dir: path.join(__dirname, 'fixtures/users'),
+    dir: join(__dirname, 'fixtures/users'),
     dirNameRoutePrefix: false,
     options: { prefix: '/user' },
   })
   fastify.register(fastifyAutoload, {
-    dir: path.join(__dirname, 'fixtures/products'),
+    dir: join(__dirname, 'fixtures/products'),
     dirNameRoutePrefix: false,
     options: { prefix: '/product' },
   })

--- a/test/cjs.test.cjs
+++ b/test/cjs.test.cjs
@@ -1,11 +1,9 @@
 const { test } = require('node:test')
 const Fastify = require('fastify')
-const fastifyRoutePresetModule = require('../index.js')
+const fastifyRoutePreset = require('../index.js')
 
 test('should support requiring the ESM entry from CommonJS', async (t) => {
-  t.plan(3)
-
-  const fastifyRoutePreset = fastifyRoutePresetModule.default
+  t.plan(1)
   const fastify = Fastify()
 
   fastify.register(fastifyRoutePreset, {
@@ -14,7 +12,5 @@ test('should support requiring the ESM entry from CommonJS', async (t) => {
 
   await fastify.ready()
 
-  t.assert.strictEqual(typeof fastifyRoutePreset, 'function')
-  t.assert.strictEqual(fastifyRoutePreset, fastifyRoutePresetModule.fastifyRoutePreset)
   t.assert.ok(fastify.hasPlugin('fastify-route-preset'))
 })

--- a/test/cjs.test.cjs
+++ b/test/cjs.test.cjs
@@ -1,0 +1,20 @@
+const { test } = require('node:test')
+const Fastify = require('fastify')
+const fastifyRoutePresetModule = require('../index.js')
+
+test('should support requiring the ESM entry from CommonJS', async (t) => {
+  t.plan(3)
+
+  const fastifyRoutePreset = fastifyRoutePresetModule.default
+  const fastify = Fastify()
+
+  fastify.register(fastifyRoutePreset, {
+    onPresetRoute: [],
+  })
+
+  await fastify.ready()
+
+  t.assert.strictEqual(typeof fastifyRoutePreset, 'function')
+  t.assert.strictEqual(fastifyRoutePreset, fastifyRoutePresetModule.fastifyRoutePreset)
+  t.assert.ok(fastify.hasPlugin('fastify-route-preset'))
+})

--- a/test/fixtures/preset.js
+++ b/test/fixtures/preset.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const presetSchema = (routeOptions, preset) => {
   routeOptions.schema = {
     ...preset.schema,
@@ -14,7 +12,4 @@ const presetVersion = (routeOptions, preset) => {
   }
 }
 
-module.exports = {
-  presetSchema,
-  presetVersion,
-}
+export { presetSchema, presetVersion }

--- a/test/fixtures/products/get.js
+++ b/test/fixtures/products/get.js
@@ -1,15 +1,13 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.get('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   preset: {
     schema: { tags: ['product'] },
     constraints: { version: '1.0.0' },

--- a/test/fixtures/products/post.js
+++ b/test/fixtures/products/post.js
@@ -1,15 +1,13 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.post('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   preset: {
     schema: { tags: ['product'] },
     constraints: { version: '1.0.0' },

--- a/test/fixtures/route.js
+++ b/test/fixtures/route.js
@@ -1,9 +1,7 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.post('/example/post', function (_req, reply) {
     reply.send({ hello: 'world' })
   })

--- a/test/fixtures/route2.js
+++ b/test/fixtures/route2.js
@@ -1,9 +1,7 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.post('/example/post', function (_req, reply) {
     reply.send({ hello: 'world' })
   })

--- a/test/fixtures/routes/product.js
+++ b/test/fixtures/routes/product.js
@@ -1,9 +1,7 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.get('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
@@ -13,7 +11,7 @@ module.exports = async function (fastify) {
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   prefix: '/product',
   preset: {
     schema: { tags: ['product'] },

--- a/test/fixtures/routes/user.js
+++ b/test/fixtures/routes/user.js
@@ -1,9 +1,7 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.get('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
@@ -13,7 +11,7 @@ module.exports = async function (fastify) {
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   prefix: '/user',
   preset: {
     schema: { tags: ['user'] },

--- a/test/fixtures/users/get.js
+++ b/test/fixtures/users/get.js
@@ -1,15 +1,13 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.get('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   preset: {
     schema: { tags: ['user'] },
     constraints: { version: '1.0.0' },

--- a/test/fixtures/users/post.js
+++ b/test/fixtures/users/post.js
@@ -1,15 +1,13 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginAsync<>}
  */
-module.exports = async function (fastify) {
+export default async function (fastify) {
   fastify.post('/', function (_req, reply) {
     reply.send({ hello: 'world' })
   })
 }
 
-module.exports.autoConfig = {
+export const autoConfig = {
   preset: {
     schema: { tags: ['user'] },
     constraints: { version: '1.0.0' },

--- a/test/fixtures/utils.js
+++ b/test/fixtures/utils.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const fp = require('fastify-plugin')
+import fp from 'fastify-plugin'
 
 const printRoutes = fp((fastify, _options, next) => {
   const routes = []
@@ -14,6 +12,4 @@ const printRoutes = fp((fastify, _options, next) => {
   next()
 })
 
-module.exports = {
-  printRoutes,
-}
+export { printRoutes }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,13 @@
-'use strict'
-
-const { test } = require('node:test')
-const Fastify = require('fastify')
-const fastifyRoutePreset = require('..')
+import { test } from 'node:test'
+import Fastify from 'fastify'
+import fastifyRoutePreset, { fastifyRoutePreset as namedFastifyRoutePreset } from '../index.js'
+import { presetSchema, presetVersion } from './fixtures/preset.js'
+import routePlugin from './fixtures/route.js'
+import route2Plugin from './fixtures/route2.js'
+import { printRoutes } from './fixtures/utils.js'
 
 test('register plugin success', async (t) => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
 
   fastify.register(fastifyRoutePreset, {
@@ -15,6 +17,7 @@ test('register plugin success', async (t) => {
   await fastify.ready()
 
   t.assert.ok(fastify.hasPlugin('fastify-route-preset'))
+  t.assert.strictEqual(fastifyRoutePreset, namedFastifyRoutePreset)
 })
 
 test('should require "onPresetRoute"', async (t) => {
@@ -89,7 +92,7 @@ test('should run "onPresetRoute"', async (t) => {
     },
   })
 
-  fastify.register(require('./fixtures/route'), {
+  fastify.register(routePlugin, {
     preset: {
       constraints: { version: '1.0.0' },
     },
@@ -104,7 +107,7 @@ test('should apply presetOptions to routeOptions', async (t) => {
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
     onPresetRoute: (routeOptions, presetOptions) => {
       routeOptions.constraints = {
@@ -114,7 +117,7 @@ test('should apply presetOptions to routeOptions', async (t) => {
     },
   })
 
-  fastify.register(require('./fixtures/route'), {
+  fastify.register(routePlugin, {
     preset: {
       constraints: { version: '1.0.0' },
     },
@@ -133,7 +136,7 @@ test('should apply schema to routeOptions', async (t) => {
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
     onPresetRoute: (routeOptions, presetOptions) => {
       routeOptions.schema = {
@@ -143,7 +146,7 @@ test('should apply schema to routeOptions', async (t) => {
     },
   })
 
-  fastify.register(require('./fixtures/route'), {
+  fastify.register(routePlugin, {
     preset: {
       schema: { tags: ['example'] },
     },
@@ -162,7 +165,7 @@ test('should work with multiple presets', async (t) => {
   t.plan(5)
   const fastify = Fastify()
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
     onPresetRoute: (routeOptions, presetOptions) => {
       routeOptions.schema = {
@@ -172,13 +175,13 @@ test('should work with multiple presets', async (t) => {
     },
   })
 
-  fastify.register(require('./fixtures/route'), {
+  fastify.register(routePlugin, {
     prefix: '/route1',
     preset: {
       schema: { tags: ['route1'] },
     },
   })
-  fastify.register(require('./fixtures/route2'), {
+  fastify.register(route2Plugin, {
     prefix: '/route2',
     preset: {
       schema: { tags: ['route2'] },
@@ -200,15 +203,12 @@ test('should work with array of "onPresetRoute"', async (t) => {
   t.plan(5)
   const fastify = Fastify()
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
-    onPresetRoute: [
-      require('./fixtures/preset').presetSchema,
-      require('./fixtures/preset').presetVersion,
-    ],
+    onPresetRoute: [presetSchema, presetVersion],
   })
 
-  fastify.register(require('./fixtures/route'), {
+  fastify.register(routePlugin, {
     preset: {
       schema: { tags: ['example'] },
       constraints: { version: '1.0.0' },
@@ -232,7 +232,7 @@ test('should ignore route preset if "skipPreset" config are true', async (t) => 
 
   let presetCalls = 0
 
-  fastify.register(require('./fixtures/utils').printRoutes)
+  fastify.register(printRoutes)
   fastify.register(fastifyRoutePreset, {
     onPresetRoute: (routeOptions, presetOptions) => {
       routeOptions.schema = {


### PR DESCRIPTION
## Summary
- Switched the package to native ESM with `type: module` and an ESM `exports` map
- Updated the plugin entrypoint and type declarations for default and named ESM exports
- Converted tests, fixtures, and autoload examples to ESM-compatible imports/exports
- Updated the README autoload snippet for ESM path handling

## Testing
- `npm run lint` passed
- `npm test` passed, including unit tests and TypeScript checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated package from CommonJS to ES modules (ESM) for improved compatibility with modern JavaScript tooling.
  * Updated package exports configuration with explicit type, import, and default entry points.

* **Documentation**
  * Added re-exported type aliases (`FastifyRoutePresetOptions`, `OnPresetRoute`) for improved type clarity and accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inyourtime/fastify-route-preset/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->